### PR TITLE
Vagrant & Quick-Start Cleanup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,7 +30,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.synced_folder ".", "/srv/salt/"
 
   config.vm.provider "virtualbox" do |vb|
-     vb.gui = true
      vb.customize ["modifyvm", :id, "--memory", "1024"]
   end
   config.vm.provision :salt do |salt|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,13 +14,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       arch.vm.hostname = "arch"
   end
 
-  config.vm.define "ubuntu1204" do |ubuntu|
-      ubuntu.vm.box = "presise64"
-      ubuntu.vm.box_url = "http://files.vagrantup.com/precise64.box"
-      ubuntu.vm.hostname = "precise64"
-  end
-
-  config.vm.define "dc" do |dc|
+  config.vm.define "dc", :autostart => false do |dc|
      dc.vm.box = "archlinux-x86_64"
      dc.vm.box_url = "http://cloud.terry.im/vagrant/archlinux-x86_64.box"
      dc.vm.hostname = "dc"
@@ -30,6 +24,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
      end
   end
 
+  # work-around for issue with salt bootstrap
+  config.vm.provision :shell, :inline => "pacman --noconfirm -S community/lsb-release"
 
   config.vm.synced_folder ".", "/srv/salt/"
 
@@ -41,5 +37,4 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       salt.minion_config = "vagrant/minion"
       salt.run_highstate = true
   end
-
 end

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,6 @@ SaltStack for Pumping Station: One
 Supported Platforms
 -------------------
 
-* Ubuntu 12.04
 * Arch Linux
 
 Install Configurations


### PR DESCRIPTION
A few things in here, all around bringing up an initial dev environment:
- remove ubuntu from the Vagrantfile (and readme), since we're moving towards arch
- don't autostart "dc" host. The idea being that it is a special case, and that the arch box is what people would generally want. Hopefully more people will add their own special cases (mail, nagios, etc...), and it would be pretty taxing on system resources to bring all hosts up by default.
- install lsb-release before kicking off salt. I was getting errors without this.. it seems to be an issue with the salt bootstrap script and arch

- don't enable the gui. I'm happy to roll this back if it's in there because people want it. I'm assuming that most people would want to use "vagrant ssh" rather than the gui.